### PR TITLE
foogod/go-powerwall#6 Update Timeout to int64 to avoid error

### DIFF
--- a/meters.go
+++ b/meters.go
@@ -1,8 +1,7 @@
 // Functions for reading power meter data:
 //
-//   (*Client) GetMeters(category string)
-//   (*Client) GetMetersAggregates()
-//
+//	(*Client) GetMeters(category string)
+//	(*Client) GetMetersAggregates()
 package powerwall
 
 import (
@@ -32,7 +31,7 @@ type MeterAggregatesData struct {
 	ICCurrent                         float32   `json:"i_c_current"`
 	LastPhaseVoltageCommunicationTime time.Time `json:"last_phase_voltage_communication_time"`
 	LastPhasePowerCommunicationTime   time.Time `json:"last_phase_power_communication_time"`
-	Timeout                           int       `json:"timeout"`
+	Timeout                           int64     `json:"timeout"`
 	NumMetersAggregated               int       `json:"num_meters_aggregated"`
 	InstantTotalCurrent               float32   `json:"instant_total_current"`
 }
@@ -93,7 +92,7 @@ type MeterData struct {
 		ReactivePowerB                    float32   `json:"reactive_power_b"`
 		LastPhasePowerCommunicationTime   time.Time `json:"last_phase_power_communication_time"`
 		SerialNumber                      string    `json:"serial_number"`
-		Timeout                           int       `json:"timeout"`
+		Timeout                           int64     `json:"timeout"`
 		InstantTotalCurrent               float32   `json:"instant_total_current"`
 	} `json:"Cached_readings"`
 	CtVoltageReferences struct {


### PR DESCRIPTION
Resolves foogod/go-powerwall#6

- [x] Update `Timeout` to `int64` to avoid 'cannot unmarshal number 60000000000' error

## Testing

1. Clone the HomeKit powerwall app: `git clone https://github.com/sighmon/homekit-powerwall`
1. Add `replace github.com/foogod/go-powerwall => github.com/sighmon/go-powerwall v0.0.0-20240116104430-7e4a9dc82d72` to `go.mod` under the direct dependencies
1. Run `go mod tidy`
1. Run the app and note that the unmarshal error no longer happens: `go run homekit-powerwall.go -ip POWERWALL_IP -username YOUR_USERNAME -password YOUR_PASSWORD -prometheusExporter`